### PR TITLE
Extend pragma to quiet the linter

### DIFF
--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -83,7 +83,7 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
     });
 
     final ignore =
-        '// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations';
+        '// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations unnecessary_brace_in_string_interps';
     final emitter = DartEmitter();
     return DartFormatter().format('$ignore\n${classBuilder.accept(emitter)}');
   }


### PR DESCRIPTION
URLs are generated with string interpolation. The https://dart-lang.github.io/linter/lints/unnecessary_brace_in_string_interps.html lint warns that {} braces are used when not necessary.